### PR TITLE
Hide search filter wrappers.

### DIFF
--- a/catppuccin.user.css
+++ b/catppuccin.user.css
@@ -306,5 +306,13 @@
             color: @text !important;
             background-color: @mantle !important;
         }
+
+        .search-filters-wrap:before {
+            display: none !important;
+        }
+        .search-filters-wrap:after {
+            display: none !important;
+        }
+      
     }
 }


### PR DESCRIPTION
I am using the Vivaldi browser and I've encountered an issue with gradients around search filters. 
![Screenshot_duck_duck_go](https://github.com/rubyowo/duckduckgo/assets/29952734/9d958f41-45e8-4bdb-a98f-2c55b3f725ed)

I've found a way to hide them, but i have no experience with Stylus and web development.
